### PR TITLE
Implement admin dashboard for Sonix

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -1,0 +1,54 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabaseClient'
+import Spinner from '@/components/Spinner'
+import { useToast } from '@/lib/useToast'
+
+interface Track {
+  id: string
+  title: string
+  play_count: number
+}
+
+export default function AnalyticsPage() {
+  const [tracks, setTracks] = useState<Track[]>([])
+  const [totalPlays, setTotalPlays] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const { show, Toast } = useToast()
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('tracks')
+        .select('id,title,play_count')
+        .order('play_count', { ascending: false })
+        .limit(10)
+      if (error) show(error.message)
+      else {
+        setTracks(data || [])
+        setTotalPlays((data || []).reduce((sum, t) => sum + (t.play_count || 0), 0))
+      }
+      setLoading(false)
+    }
+    load()
+  }, [show])
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-lg font-bold">Analytics</h1>
+      {loading && <Spinner />}
+      {!loading && (
+        <div className="space-y-2">
+          <div>Total plays: {totalPlays}</div>
+          <h2 className="font-semibold">Top Tracks</h2>
+          <ol className="list-decimal list-inside">
+            {tracks.map((t) => (
+              <li key={t.id}>{t.title} – {t.play_count}</li>
+            ))}
+          </ol>
+        </div>
+      )}
+      <Toast />
+    </div>
+  )
+}

--- a/app/dashboard/artists/page.tsx
+++ b/app/dashboard/artists/page.tsx
@@ -1,0 +1,102 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabaseClient'
+import Spinner from '@/components/Spinner'
+import { useToast } from '@/lib/useToast'
+
+interface Artist {
+  id: string
+  name: string
+  is_verified: boolean
+  bio: string | null
+  twitter_url: string | null
+  instagram_url: string | null
+}
+
+export default function ArtistsPage() {
+  const [artists, setArtists] = useState<Artist[]>([])
+  const [loading, setLoading] = useState(true)
+  const { show, Toast } = useToast()
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('artists')
+        .select('id,name,is_verified,bio,twitter_url,instagram_url')
+      if (error) show(error.message)
+      else setArtists(data || [])
+      setLoading(false)
+    }
+    load()
+  }, [show])
+
+  const updateArtist = async (id: string, payload: Partial<Artist>) => {
+    setLoading(true)
+    const { error } = await supabase.from('artists').update(payload).eq('id', id)
+    if (error) show(error.message)
+    else show('Artist updated')
+    setLoading(false)
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-lg font-bold">Artist Verification</h1>
+      {loading && <Spinner />}
+      {!loading && (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Name</th>
+              <th className="p-2">Verified</th>
+              <th className="p-2">Bio</th>
+              <th className="p-2">Twitter</th>
+              <th className="p-2">Instagram</th>
+            </tr>
+          </thead>
+          <tbody>
+            {artists.map((a) => (
+              <tr key={a.id} className="border-t">
+                <td className="p-2">{a.name}</td>
+                <td className="p-2">
+                  <input
+                    type="checkbox"
+                    checked={a.is_verified}
+                    onChange={(e) =>
+                      updateArtist(a.id, { is_verified: e.target.checked })
+                    }
+                  />
+                </td>
+                <td className="p-2">
+                  <input
+                    className="border p-1 w-40"
+                    value={a.bio || ''}
+                    onChange={(e) => updateArtist(a.id, { bio: e.target.value })}
+                  />
+                </td>
+                <td className="p-2">
+                  <input
+                    className="border p-1 w-40"
+                    value={a.twitter_url || ''}
+                    onChange={(e) =>
+                      updateArtist(a.id, { twitter_url: e.target.value })
+                    }
+                  />
+                </td>
+                <td className="p-2">
+                  <input
+                    className="border p-1 w-40"
+                    value={a.instagram_url || ''}
+                    onChange={(e) =>
+                      updateArtist(a.id, { instagram_url: e.target.value })
+                    }
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <Toast />
+    </div>
+  )
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,18 @@
+'use client'
+import Link from 'next/link'
+
+export default function DashboardLayout({children}:{children:React.ReactNode}){
+  return (
+    <div className="min-h-screen md:flex">
+      <nav className="bg-gray-100 p-safe flex gap-4 md:flex-col md:w-48">
+        <Link href="/dashboard/users" className="hover:underline">Users</Link>
+        <Link href="/dashboard/artists" className="hover:underline">Artists</Link>
+        <Link href="/dashboard/analytics" className="hover:underline">Analytics</Link>
+        <Link href="/dashboard/notifications" className="hover:underline">Notifications</Link>
+        <Link href="/dashboard/publishing" className="hover:underline">Publishing</Link>
+        <Link href="/dashboard/merch" className="hover:underline">Merch</Link>
+      </nav>
+      <main className="flex-1 p-safe">{children}</main>
+    </div>
+  )
+}

--- a/app/dashboard/merch/page.tsx
+++ b/app/dashboard/merch/page.tsx
@@ -1,0 +1,75 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabaseClient'
+import Spinner from '@/components/Spinner'
+import { useToast } from '@/lib/useToast'
+
+interface Product {
+  id: string
+  name: string
+  price: number
+  inventory: number
+}
+
+export default function MerchPage() {
+  const [products, setProducts] = useState<Product[]>([])
+  const [name, setName] = useState('')
+  const [price, setPrice] = useState(0)
+  const [inventory, setInventory] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const { show, Toast } = useToast()
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase.from('products').select('id,name,price,inventory')
+      if (error) show(error.message)
+      else setProducts(data || [])
+      setLoading(false)
+    }
+    load()
+  }, [show])
+
+  const addProduct = async () => {
+    const { error } = await supabase.from('products').insert({ name, price, inventory })
+    if (error) show(error.message)
+    else show('Product added')
+  }
+
+  const updateInventory = async (id: string, inv: number) => {
+    const { error } = await supabase.from('products').update({ inventory: inv }).eq('id', id)
+    if (error) show(error.message)
+    else show('Inventory updated')
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-lg font-bold">Merchandising</h1>
+      <div className="space-y-2 border p-2 rounded">
+        <input className="border p-1 w-full" placeholder="Name" value={name} onChange={(e)=>setName(e.target.value)} />
+        <input className="border p-1 w-full" type="number" placeholder="Price" value={price} onChange={(e)=>setPrice(parseFloat(e.target.value))} />
+        <input className="border p-1 w-full" type="number" placeholder="Inventory" value={inventory} onChange={(e)=>setInventory(parseInt(e.target.value))} />
+        <button className="bg-black text-white px-3 py-1 rounded" onClick={addProduct}>Add</button>
+      </div>
+      {loading && <Spinner />}
+      {!loading && (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left"><th className="p-2">Name</th><th className="p-2">Price</th><th className="p-2">Inventory</th></tr>
+          </thead>
+          <tbody>
+            {products.map(p=> (
+              <tr key={p.id} className="border-t">
+                <td className="p-2">{p.name}</td>
+                <td className="p-2">${p.price}</td>
+                <td className="p-2">
+                  <input type="number" className="border p-1 w-16" value={p.inventory} onChange={(e)=>updateInventory(p.id, parseInt(e.target.value))} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <Toast />
+    </div>
+  )
+}

--- a/app/dashboard/notifications/page.tsx
+++ b/app/dashboard/notifications/page.tsx
@@ -1,0 +1,83 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabaseClient'
+import Spinner from '@/components/Spinner'
+import { useToast } from '@/lib/useToast'
+
+interface Notification {
+  id: string
+  title: string
+  message: string
+  send_at: string | null
+}
+
+export default function NotificationsPage() {
+  const [notifs, setNotifs] = useState<Notification[]>([])
+  const [title, setTitle] = useState('')
+  const [message, setMessage] = useState('')
+  const [sendAt, setSendAt] = useState('')
+  const [loading, setLoading] = useState(true)
+  const { show, Toast } = useToast()
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('notifications')
+        .select('id,title,message,send_at')
+        .order('created_at', { ascending: false })
+      if (error) show(error.message)
+      else setNotifs(data || [])
+      setLoading(false)
+    }
+    load()
+  }, [show])
+
+  const createNotif = async () => {
+    const payload: { title: string; message: string; send_at?: string } = {
+      title,
+      message,
+    }
+    if (sendAt) payload.send_at = sendAt
+    const { error } = await supabase.from('notifications').insert(payload)
+    if (error) show(error.message)
+    else show('Notification scheduled')
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-lg font-bold">Push Notifications</h1>
+      <div className="space-y-2 border p-2 rounded">
+        <input
+          className="border p-1 w-full"
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <textarea
+          className="border p-1 w-full"
+          placeholder="Message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+        <input
+          className="border p-1 w-full"
+          type="datetime-local"
+          value={sendAt}
+          onChange={(e) => setSendAt(e.target.value)}
+        />
+        <button className="bg-black text-white px-3 py-1 rounded" onClick={createNotif}>
+          Send / Schedule
+        </button>
+      </div>
+      {loading && <Spinner />}
+      {!loading && (
+        <ul className="list-disc list-inside">
+          {notifs.map((n) => (
+            <li key={n.id}>{n.title} – {n.send_at ?? 'instant'}</li>
+          ))}
+        </ul>
+      )}
+      <Toast />
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,8 @@
+export default function DashboardPage(){
+  return (
+    <div>
+      <h1 className="text-xl font-bold">Admin Dashboard</h1>
+      <p>Select a section from the navigation.</p>
+    </div>
+  )
+}

--- a/app/dashboard/publishing/page.tsx
+++ b/app/dashboard/publishing/page.tsx
@@ -1,0 +1,73 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabaseClient'
+import Spinner from '@/components/Spinner'
+import { useToast } from '@/lib/useToast'
+
+interface Item {
+  id: string
+  title: string
+  scheduled_publish_at: string | null
+}
+
+export default function PublishingPage() {
+  const [items, setItems] = useState<Item[]>([])
+  const [loading, setLoading] = useState(true)
+  const { show, Toast } = useToast()
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('tracks')
+        .select('id,title,scheduled_publish_at')
+      if (error) show(error.message)
+      else setItems(data || [])
+      setLoading(false)
+    }
+    load()
+  }, [show])
+
+  const update = async (id: string, date: string) => {
+    setLoading(true)
+    const { error } = await supabase
+      .from('tracks')
+      .update({ scheduled_publish_at: date || null })
+      .eq('id', id)
+    if (error) show(error.message)
+    else show('Updated')
+    setLoading(false)
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-lg font-bold">Timed Publishing</h1>
+      {loading && <Spinner />}
+      {!loading && (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Title</th>
+              <th className="p-2">Publish at</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((i) => (
+              <tr key={i.id} className="border-t">
+                <td className="p-2">{i.title}</td>
+                <td className="p-2">
+                  <input
+                    type="datetime-local"
+                    className="border p-1"
+                    value={i.scheduled_publish_at?.slice(0,16) || ''}
+                    onChange={(e) => update(i.id, e.target.value)}
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <Toast />
+    </div>
+  )
+}

--- a/app/dashboard/users/page.tsx
+++ b/app/dashboard/users/page.tsx
@@ -1,0 +1,73 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabaseClient'
+import Spinner from '@/components/Spinner'
+import { useToast } from '@/lib/useToast'
+
+interface User {
+  id: string
+  email: string
+  role: string | null
+}
+
+export default function UsersPage() {
+  const [users, setUsers] = useState<User[]>([])
+  const [loading, setLoading] = useState(true)
+  const { show, Toast } = useToast()
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase.from('users').select('id,email,role')
+      if (error) {
+        show(error.message)
+      } else {
+        setUsers(data || [])
+      }
+      setLoading(false)
+    }
+    load()
+  }, [show])
+
+  const updateRole = async (id: string, role: string) => {
+    setLoading(true)
+    const { error } = await supabase.from('users').update({ role }).eq('id', id)
+    if (error) show(error.message)
+    else show('Role updated')
+    setLoading(false)
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-lg font-bold">User Management</h1>
+      {loading && <Spinner />}
+      {!loading && (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Email</th>
+              <th className="p-2">Role</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.id} className="border-t">
+                <td className="p-2">{u.email}</td>
+                <td className="p-2">
+                  <select
+                    className="border p-1"
+                    value={u.role || ''}
+                    onChange={(e) => updateRole(u.id, e.target.value)}
+                  >
+                    <option value="">user</option>
+                    <option value="admin">admin</option>
+                  </select>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <Toast />
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,12 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+.p-safe {
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+.bottom-safe {
+  bottom: calc(env(safe-area-inset-bottom) + 1rem);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased p-safe`}
       >
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,11 @@
-import Image from "next/image";
+import Link from 'next/link'
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+    <div className="min-h-screen flex items-center justify-center">
+      <Link href="/dashboard" className="text-blue-600 underline">
+        Go to Admin Dashboard
+      </Link>
     </div>
-  );
+  )
 }

--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -1,0 +1,7 @@
+export default function Spinner() {
+  return (
+    <div className="flex justify-center items-center p-4">
+      <div className="h-5 w-5 animate-spin rounded-full border-2 border-gray-400 border-t-transparent"></div>
+    </div>
+  )
+}

--- a/lib/useToast.tsx
+++ b/lib/useToast.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { useState, useCallback } from 'react'
+
+export function useToast() {
+  const [message, setMessage] = useState<string | null>(null)
+
+  const show = useCallback((msg: string, duration = 3000) => {
+    setMessage(msg)
+    setTimeout(() => setMessage(null), duration)
+  }, [])
+
+  const Toast = () =>
+    message ? (
+      <div className="fixed bottom-safe left-1/2 -translate-x-1/2 bg-black text-white px-4 py-2 rounded z-50">
+        {message}
+      </div>
+    ) : null
+
+  return { show, Toast }
+}


### PR DESCRIPTION
## Summary
- add safe-area padding classes
- set layout to use safe area
- simplify home page with link to dashboard
- introduce dashboard layout with section navigation
- build management pages for users, artists, analytics, notifications, timed publishing, and merch
- create Spinner component and toast hook

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fe9c3b7948324b88fee621ef26371